### PR TITLE
feat(ui): signal detail page with trade results

### DIFF
--- a/.sqlx/query-40ec45b3c33f6914f929e0c14a97394ae48eed8b11b1f4b8e017c6064e63c9be.json
+++ b/.sqlx/query-40ec45b3c33f6914f929e0c14a97394ae48eed8b11b1f4b8e017c6064e63c9be.json
@@ -1,0 +1,46 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, signal_id, slow_tx_hash, fast_tx_hash, realized_profit_str\n            FROM successful_trade\n            WHERE signal_id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "signal_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "slow_tx_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "fast_tx_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "realized_profit_str",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "40ec45b3c33f6914f929e0c14a97394ae48eed8b11b1f4b8e017c6064e63c9be"
+}

--- a/.sqlx/query-66f439db57bf0c7d083cca3f70ff6e7d70198e61283741ae9b3bd84e007687ba.json
+++ b/.sqlx/query-66f439db57bf0c7d083cca3f70ff6e7d70198e61283741ae9b3bd84e007687ba.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, signal_id, slow_tx_hash, fast_tx_hash\n            FROM failed_on_fast_chain_trade\n            WHERE signal_id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "signal_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "slow_tx_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "fast_tx_hash",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "66f439db57bf0c7d083cca3f70ff6e7d70198e61283741ae9b3bd84e007687ba"
+}

--- a/.sqlx/query-f8e9a6d58cf5bc5d22753e3ba4f30a9e096d85ebea9c204367ff3b6ebd91ae02.json
+++ b/.sqlx/query-f8e9a6d58cf5bc5d22753e3ba4f30a9e096d85ebea9c204367ff3b6ebd91ae02.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, signal_id, slow_tx_hash\n            FROM failed_on_slow_chain_trade\n            WHERE signal_id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "signal_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "slow_tx_hash",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "f8e9a6d58cf5bc5d22753e3ba4f30a9e096d85ebea9c204367ff3b6ebd91ae02"
+}

--- a/crates/backend/src/routes/trades.rs
+++ b/crates/backend/src/routes/trades.rs
@@ -1,5 +1,5 @@
 use axum::{
-    extract::{Query, State},
+    extract::{Path, Query, State},
     http::StatusCode,
     response::{IntoResponse, Response},
     routing::get,
@@ -447,9 +447,85 @@ pub async fn get_failed_on_fast_trade_results_by_pair(
     )))
 }
 
+pub async fn get_trades_for_signal(
+    Path(signal_id): Path<i64>,
+    State(state): State<AppState>,
+) -> Result<Json<Vec<TradeResultResponse>>, Response> {
+    let trade_repo = state.db.trade_repository();
+    let signal_repo = state.db.signal_repository();
+    let spot_price_repo = state.db.spot_price_repository();
+
+    let (successful, failed_on_slow, failed_on_fast) = tokio::join!(
+        trade_repo.get_successful_by_signal_id(signal_id),
+        trade_repo.get_failed_on_slow_by_signal_id(signal_id),
+        trade_repo.get_failed_on_fast_by_signal_id(signal_id),
+    );
+
+    let mut responses: Vec<TradeResultResponse> = Vec::new();
+
+    match successful {
+        Ok(rows) => {
+            match enrich_rows(rows, signal_repo.clone(), spot_price_repo.clone(), |r| {
+                r.signal_id
+            })
+            .await
+            {
+                Ok(enriched) => responses.extend(enriched.into_iter().map(|(row, signal, slow_ts, fast_ts)| {
+                    TradeResultResponse::Successful(
+                        SuccessfulTradeResponse::from_row_and_signal(row, signal, slow_ts, fast_ts),
+                    )
+                })),
+                Err(e) => {
+                    tracing::error!("Failed to enrich successful trades for signal {}: {}", signal_id, e);
+                }
+            }
+        }
+        Err(e) => tracing::error!("Failed to fetch successful trades for signal {}: {}", signal_id, e),
+    }
+
+    match failed_on_slow {
+        Ok(rows) => {
+            match enrich_rows(rows, signal_repo.clone(), spot_price_repo.clone(), |r| {
+                r.signal_id
+            })
+            .await
+            {
+                Ok(enriched) => responses.extend(enriched.into_iter().map(|(row, signal, slow_ts, fast_ts)| {
+                    TradeResultResponse::FailedOnSlow(
+                        FailedOnSlowTradeResponse::from_row_and_signal(row, signal, slow_ts, fast_ts),
+                    )
+                })),
+                Err(e) => {
+                    tracing::error!("Failed to enrich failed-on-slow trades for signal {}: {}", signal_id, e);
+                }
+            }
+        }
+        Err(e) => tracing::error!("Failed to fetch failed-on-slow trades for signal {}: {}", signal_id, e),
+    }
+
+    match failed_on_fast {
+        Ok(rows) => {
+            match enrich_rows(rows, signal_repo, spot_price_repo, |r| r.signal_id).await {
+                Ok(enriched) => responses.extend(enriched.into_iter().map(|(row, signal, slow_ts, fast_ts)| {
+                    TradeResultResponse::FailedOnFast(
+                        FailedOnFastTradeResponse::from_row_and_signal(row, signal, slow_ts, fast_ts),
+                    )
+                })),
+                Err(e) => {
+                    tracing::error!("Failed to enrich failed-on-fast trades for signal {}: {}", signal_id, e);
+                }
+            }
+        }
+        Err(e) => tracing::error!("Failed to fetch failed-on-fast trades for signal {}: {}", signal_id, e),
+    }
+
+    Ok(Json(responses))
+}
+
 pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/", get(get_all_trade_results_by_pair))
+        .route("/by-signal/:signal_id", get(get_trades_for_signal))
         .route("/successful", get(get_successful_trade_results_by_pair))
         .route(
             "/failed-on-slow",

--- a/crates/core/src/database/trade.rs
+++ b/crates/core/src/database/trade.rs
@@ -307,4 +307,58 @@ impl TradeRepository {
         .await?;
         Ok(rows)
     }
+
+    pub async fn get_successful_by_signal_id(
+        &self,
+        signal_id: i64,
+    ) -> eyre::Result<Vec<TradeSuccessRow>> {
+        let rows = sqlx::query_as!(
+            TradeSuccessRow,
+            r#"
+            SELECT id, signal_id, slow_tx_hash, fast_tx_hash, realized_profit_str
+            FROM successful_trade
+            WHERE signal_id = $1
+            "#,
+            signal_id,
+        )
+        .fetch_all(&*self.pool)
+        .await?;
+        Ok(rows)
+    }
+
+    pub async fn get_failed_on_slow_by_signal_id(
+        &self,
+        signal_id: i64,
+    ) -> eyre::Result<Vec<TradeFailedOnSlowRow>> {
+        let rows = sqlx::query_as!(
+            TradeFailedOnSlowRow,
+            r#"
+            SELECT id, signal_id, slow_tx_hash
+            FROM failed_on_slow_chain_trade
+            WHERE signal_id = $1
+            "#,
+            signal_id,
+        )
+        .fetch_all(&*self.pool)
+        .await?;
+        Ok(rows)
+    }
+
+    pub async fn get_failed_on_fast_by_signal_id(
+        &self,
+        signal_id: i64,
+    ) -> eyre::Result<Vec<TradeFailedOnFastRow>> {
+        let rows = sqlx::query_as!(
+            TradeFailedOnFastRow,
+            r#"
+            SELECT id, signal_id, slow_tx_hash, fast_tx_hash
+            FROM failed_on_fast_chain_trade
+            WHERE signal_id = $1
+            "#,
+            signal_id,
+        )
+        .fetch_all(&*self.pool)
+        .await?;
+        Ok(rows)
+    }
 }

--- a/webapp/src/app/signals/[id]/page.tsx
+++ b/webapp/src/app/signals/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { use } from "react"
 import Link from "next/link"
 import { ArrowLeft, MoveRight } from "lucide-react"
-import { useSignal } from "@/lib/api-client"
+import { useSignal, useTradesBySignal } from "@/lib/api-client"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { ChainBadge } from "@/components/ui/chain-badge"
 import { TokenBadge } from "@/components/ui/token-badge"
@@ -12,7 +12,7 @@ import { ExplorerLink } from "@/components/ui/explorer-link"
 import { BlockCell } from "@/components/ui/block-cell"
 import { HoverPopover } from "@/components/ui/hover-popover"
 import { Button } from "@/components/ui/button"
-import { SpotPrice } from "@/lib/types"
+import { SpotPrice, TradeResult } from "@/lib/types"
 
 function Row({ label, children }: { label: string; children: React.ReactNode }) {
   return (
@@ -43,6 +43,91 @@ function SpotPriceRow({ tokenA, tokenB, price }: { tokenA: string; tokenB: strin
         <span><span className="text-muted-foreground">max </span>{price.max_price.toFixed(6)}</span>
       </div>
     </div>
+  )
+}
+
+const TRADE_TYPE_LABELS: Record<TradeResult['trade_type'], string> = {
+  Successful: 'Successful',
+  FailedOnSlow: 'Failed',
+  FailedOnFast: 'Stuck',
+}
+
+const TRADE_TYPE_COLORS: Record<TradeResult['trade_type'], string> = {
+  Successful: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+  FailedOnSlow: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
+  FailedOnFast: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
+}
+
+function TradeTypeBadge({ type }: { type: TradeResult['trade_type'] }) {
+  return (
+    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${TRADE_TYPE_COLORS[type]}`}>
+      {TRADE_TYPE_LABELS[type]}
+    </span>
+  )
+}
+
+function TradeResultRow({ trade }: { trade: TradeResult }) {
+  const { trade_type, trade_data } = trade
+  const slowChain = trade_data.signal.slow.chain
+  const fastChain = trade_data.signal.fast.chain
+
+  return (
+    <div className="flex flex-col gap-2 py-3 border-b last:border-0">
+      <div className="flex items-center gap-3">
+        <TradeTypeBadge type={trade_type} />
+        <span className="text-sm text-muted-foreground font-mono">#{trade_data.id}</span>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-1 pl-2">
+        <Row label="Slow Tx">
+          {trade_type === 'FailedOnSlow' && !trade_data.slow_tx_hash
+            ? <span className="text-muted-foreground">—</span>
+            : <ExplorerLink chain={slowChain} type="tx" value={trade_data.slow_tx_hash!} />
+          }
+        </Row>
+        <Row label="Fast Tx">
+          {trade_type === 'Successful'
+            ? <ExplorerLink chain={fastChain} type="tx" value={trade_data.fast_tx_hash} />
+            : trade_type === 'FailedOnFast' && trade_data.fast_tx_hash
+              ? <ExplorerLink chain={fastChain} type="tx" value={trade_data.fast_tx_hash} />
+              : <span className="text-muted-foreground">—</span>
+          }
+        </Row>
+        {trade_type === 'Successful' && (
+          <Row label="Realized Profit">
+            <span className="font-mono text-xs">{trade_data.realized_profit_str}</span>
+          </Row>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function TradeResultsCard({ signalId }: { signalId: number }) {
+  const { data: trades, isLoading } = useTradesBySignal(signalId, {
+    staleTime: 1000 * 60 * 5,
+  })
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Trade Results</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="text-sm text-muted-foreground py-4 text-center">Loading trades...</div>
+        ) : !trades || trades.length === 0 ? (
+          <div className="text-sm text-muted-foreground py-4 text-center">
+            No trades have been executed for this signal.
+          </div>
+        ) : (
+          <div>
+            {trades.map((trade) => (
+              <TradeResultRow key={`${trade.trade_type}-${trade.trade_data.id}`} trade={trade} />
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
   )
 }
 
@@ -238,6 +323,9 @@ export default function SignalPage({ params }: { params: Promise<{ id: string }>
           <SpotPriceRow tokenA="ETH" tokenB="USDC" price={signal.slow_prices_eth_usdc} />
         </CardContent>
       </Card>
+
+      {/* Trade Results */}
+      <TradeResultsCard signalId={signalId} />
     </main>
   )
 }

--- a/webapp/src/lib/api-client.tsx
+++ b/webapp/src/lib/api-client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { SpotPrice, Signal, SuccessfulTrade, FailedOnSlowTrade, FailedOnFastTrade, PaginatedResponse } from "@/lib/types";
+import { SpotPrice, Signal, SuccessfulTrade, FailedOnSlowTrade, FailedOnFastTrade, TradeResult, PaginatedResponse } from "@/lib/types";
 import { QueryClient, useQuery, useQueryClient, UseQueryOptions, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { useStrategy } from "@/components/strategy-provider";
@@ -59,6 +59,10 @@ class ApiClient {
 
   async getSignal(id: number): Promise<Signal> {
     return this.requestSingle<Signal>(`/signals/${id}`);
+  }
+
+  async getTradesBySignal(signalId: number): Promise<TradeResult[]> {
+    return this.requestSingle<TradeResult[]>(`/trades/by-signal/${signalId}`);
   }
 
   async getSignals(pair: string, params: FetchParams): Promise<PaginatedResponse<Signal>> {
@@ -133,6 +137,14 @@ export function useSignal(id: number, options?: Partial<UseQueryOptions<Signal>>
     ...options,
     queryKey: ['signal', id],
     queryFn: () => apiClient.getSignal(id),
+  });
+}
+
+export function useTradesBySignal(signalId: number, options?: Partial<UseQueryOptions<TradeResult[]>>) {
+  return useQuery<TradeResult[]>({
+    ...options,
+    queryKey: ['trades_by_signal', signalId],
+    queryFn: () => apiClient.getTradesBySignal(signalId),
   });
 }
 

--- a/webapp/src/lib/types.ts
+++ b/webapp/src/lib/types.ts
@@ -88,6 +88,12 @@ export interface FailedOnFastTrade {
   fast_tx_hash: string | null;
 }
 
+// Matches TradeResultResponse tagged enum
+export type TradeResult =
+  | { trade_type: 'Successful'; trade_data: SuccessfulTrade }
+  | { trade_type: 'FailedOnSlow'; trade_data: FailedOnSlowTrade }
+  | { trade_type: 'FailedOnFast'; trade_data: FailedOnFastTrade }
+
 export interface PaginationInfo {
   page: number;
   page_size: number;


### PR DESCRIPTION
## Summary

- Adds a new `/signals/[id]` detail page showing the full signal breakdown (slow/fast swap legs, expected profit, spot prices at signal time, and all trade outcomes)
- Adds `GET /signals/:id` and `GET /trades/by-signal/:signal_id` backend endpoints
- Adds a token pair selector to the dashboard so users can switch between configured strategies
- Adds short descriptions to each dashboard table card clarifying what each section represents
- Updates Signal ID cells in all tables to link to the signal detail page instead of in-page anchors

## Changes by file

| File | Change |
|------|--------|
| `crates/backend/src/routes/signals.rs` | Add `GET /signals/:id` endpoint using existing `signal_repo.get_by_id` |
| `crates/backend/src/routes/trades.rs` | Add `GET /trades/by-signal/:signal_id` endpoint, returns all trade types for a signal |
| `crates/core/src/database/trade.rs` | Add `get_successful/failed_on_slow/failed_on_fast_by_signal_id` DB query methods |
| `.sqlx/` | Updated offline query cache for the three new sqlx queries |
| `webapp/src/app/signals/[id]/page.tsx` | New signal detail page: swap legs, expected profit, spot prices, trade results card |
| `webapp/src/lib/types.ts` | Add `TradeResult` discriminated union type matching backend tagged enum |
| `webapp/src/lib/api-client.tsx` | Add `getSignal`, `getTradesBySignal` methods and `useSignal`, `useTradesBySignal` hooks |
| `webapp/src/components/strategy-provider.tsx` | New context provider exposing the active token pair |
| `webapp/src/components/strategy-card.tsx` | Token pair selector UI integrated into strategy card |
| `webapp/src/app/page.tsx` | Add `CardDescription` to each table card |
| `webapp/src/components/*/columns.tsx` | Signal ID links updated from `#signal-N` anchors to `/signals/N` |

## Test plan

- Start DB with `just db-start`, seed with `just db-migrate-test`
- Start backend with `just backend`, verify `curl http://localhost:8080/signals/1` and `curl http://localhost:8080/trades/by-signal/1`
- Start frontend with `just webapp-dev`, open `http://localhost:3000`
- Click a Signal ID in any table → confirm navigation to `/signals/N`
- Verify Trade Results card at bottom of signal page shows Successful/Failed/Stuck badges with tx links
- Verify signal with no trades shows empty state

🤖 Generated with [Claude Code](https://claude.com/claude-code)