### PR TITLE
feat(webapp): show trade result on signal detail page

### DIFF
--- a/.sqlx/query-40ec45b3c33f6914f929e0c14a97394ae48eed8b11b1f4b8e017c6064e63c9be.json
+++ b/.sqlx/query-40ec45b3c33f6914f929e0c14a97394ae48eed8b11b1f4b8e017c6064e63c9be.json
@@ -1,0 +1,46 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, signal_id, slow_tx_hash, fast_tx_hash, realized_profit_str\n            FROM successful_trade\n            WHERE signal_id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "signal_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "slow_tx_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "fast_tx_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "realized_profit_str",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "40ec45b3c33f6914f929e0c14a97394ae48eed8b11b1f4b8e017c6064e63c9be"
+}

--- a/.sqlx/query-66f439db57bf0c7d083cca3f70ff6e7d70198e61283741ae9b3bd84e007687ba.json
+++ b/.sqlx/query-66f439db57bf0c7d083cca3f70ff6e7d70198e61283741ae9b3bd84e007687ba.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, signal_id, slow_tx_hash, fast_tx_hash\n            FROM failed_on_fast_chain_trade\n            WHERE signal_id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "signal_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "slow_tx_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "fast_tx_hash",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "66f439db57bf0c7d083cca3f70ff6e7d70198e61283741ae9b3bd84e007687ba"
+}

--- a/.sqlx/query-f8e9a6d58cf5bc5d22753e3ba4f30a9e096d85ebea9c204367ff3b6ebd91ae02.json
+++ b/.sqlx/query-f8e9a6d58cf5bc5d22753e3ba4f30a9e096d85ebea9c204367ff3b6ebd91ae02.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, signal_id, slow_tx_hash\n            FROM failed_on_slow_chain_trade\n            WHERE signal_id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "signal_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "slow_tx_hash",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "f8e9a6d58cf5bc5d22753e3ba4f30a9e096d85ebea9c204367ff3b6ebd91ae02"
+}

--- a/crates/backend/src/routes/trades.rs
+++ b/crates/backend/src/routes/trades.rs
@@ -14,7 +14,7 @@
 //! alongside trade-specific fields (tx hashes, realized profit).
 
 use axum::{
-    extract::{Query, State},
+    extract::{Path, Query, State},
     http::StatusCode,
     response::{IntoResponse, Response},
     routing::get,
@@ -462,6 +462,99 @@ pub async fn get_failed_on_fast_trade_results_by_pair(
     )))
 }
 
+/// Slim trade result for the signal detail page — omits the embedded signal since
+/// the caller already has it. Uses internally-tagged serde so `trade_type` is a
+/// top-level field alongside the trade-specific fields.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(tag = "trade_type")]
+pub enum SignalTradeResultResponse {
+    Successful {
+        id: i64,
+        slow_tx_hash: String,
+        fast_tx_hash: String,
+        realized_profit_str: String,
+    },
+    FailedOnSlow {
+        id: i64,
+        slow_tx_hash: Option<String>,
+    },
+    FailedOnFast {
+        id: i64,
+        slow_tx_hash: String,
+        fast_tx_hash: Option<String>,
+    },
+}
+
+/// `GET /trades/by-signal/:signal_id` — return the trade result(s) for a specific signal.
+///
+/// There should be at most one trade per signal in practice, but the response is a
+/// `Vec` to be forward-compatible if that assumption changes. Returns an empty list
+/// when no trade has been recorded for the signal.
+pub async fn get_trades_by_signal(
+    Path(signal_id): Path<i64>,
+    State(state): State<AppState>,
+) -> Result<Json<Vec<SignalTradeResultResponse>>, Response> {
+    let trade_repo = state.db.trade_repository();
+
+    let (success, failed_slow, failed_fast) = tokio::join!(
+        trade_repo.get_successful_by_signal_id(signal_id),
+        trade_repo.get_failed_on_slow_by_signal_id(signal_id),
+        trade_repo.get_failed_on_fast_by_signal_id(signal_id),
+    );
+
+    let mut results: Vec<SignalTradeResultResponse> = Vec::new();
+
+    match success {
+        Ok(Some(row)) => results.push(SignalTradeResultResponse::Successful {
+            id: row.id,
+            slow_tx_hash: row.slow_tx_hash,
+            fast_tx_hash: row.fast_tx_hash,
+            realized_profit_str: row.realized_profit_str,
+        }),
+        Ok(None) => {}
+        Err(e) => {
+            tracing::error!("Failed to fetch successful trade for signal {}: {}", signal_id, e);
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "Database error" })),
+            ).into_response());
+        }
+    }
+
+    match failed_slow {
+        Ok(Some(row)) => results.push(SignalTradeResultResponse::FailedOnSlow {
+            id: row.id,
+            slow_tx_hash: row.slow_tx_hash,
+        }),
+        Ok(None) => {}
+        Err(e) => {
+            tracing::error!("Failed to fetch failed-on-slow trade for signal {}: {}", signal_id, e);
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "Database error" })),
+            ).into_response());
+        }
+    }
+
+    match failed_fast {
+        Ok(Some(row)) => results.push(SignalTradeResultResponse::FailedOnFast {
+            id: row.id,
+            slow_tx_hash: row.slow_tx_hash,
+            fast_tx_hash: row.fast_tx_hash,
+        }),
+        Ok(None) => {}
+        Err(e) => {
+            tracing::error!("Failed to fetch failed-on-fast trade for signal {}: {}", signal_id, e);
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "Database error" })),
+            ).into_response());
+        }
+    }
+
+    Ok(Json(results))
+}
+
 pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/", get(get_all_trade_results_by_pair))
@@ -474,4 +567,5 @@ pub fn routes() -> Router<AppState> {
             "/failed-on-fast",
             get(get_failed_on_fast_trade_results_by_pair),
         )
+        .route("/by-signal/:signal_id", get(get_trades_by_signal))
 }

--- a/crates/core/src/database/trade.rs
+++ b/crates/core/src/database/trade.rs
@@ -338,4 +338,58 @@ impl TradeRepository {
         .await?;
         Ok(rows)
     }
+
+    pub async fn get_successful_by_signal_id(
+        &self,
+        signal_id: i64,
+    ) -> eyre::Result<Option<TradeSuccessRow>> {
+        let row = sqlx::query_as!(
+            TradeSuccessRow,
+            r#"
+            SELECT id, signal_id, slow_tx_hash, fast_tx_hash, realized_profit_str
+            FROM successful_trade
+            WHERE signal_id = $1
+            "#,
+            signal_id,
+        )
+        .fetch_optional(&*self.pool)
+        .await?;
+        Ok(row)
+    }
+
+    pub async fn get_failed_on_slow_by_signal_id(
+        &self,
+        signal_id: i64,
+    ) -> eyre::Result<Option<TradeFailedOnSlowRow>> {
+        let row = sqlx::query_as!(
+            TradeFailedOnSlowRow,
+            r#"
+            SELECT id, signal_id, slow_tx_hash
+            FROM failed_on_slow_chain_trade
+            WHERE signal_id = $1
+            "#,
+            signal_id,
+        )
+        .fetch_optional(&*self.pool)
+        .await?;
+        Ok(row)
+    }
+
+    pub async fn get_failed_on_fast_by_signal_id(
+        &self,
+        signal_id: i64,
+    ) -> eyre::Result<Option<TradeFailedOnFastRow>> {
+        let row = sqlx::query_as!(
+            TradeFailedOnFastRow,
+            r#"
+            SELECT id, signal_id, slow_tx_hash, fast_tx_hash
+            FROM failed_on_fast_chain_trade
+            WHERE signal_id = $1
+            "#,
+            signal_id,
+        )
+        .fetch_optional(&*self.pool)
+        .await?;
+        Ok(row)
+    }
 }

--- a/webapp/src/app/signals/[id]/page.tsx
+++ b/webapp/src/app/signals/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { use } from "react"
 import Link from "next/link"
 import { ArrowLeft, MoveRight } from "lucide-react"
-import { useSignal } from "@/lib/api-client"
+import { useSignal, useTradesBySignal } from "@/lib/api-client"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { ChainBadge } from "@/components/ui/chain-badge"
 import { TokenBadge } from "@/components/ui/token-badge"
@@ -12,7 +12,7 @@ import { ExplorerLink } from "@/components/ui/explorer-link"
 import { BlockCell } from "@/components/ui/block-cell"
 import { HoverPopover } from "@/components/ui/hover-popover"
 import { Button } from "@/components/ui/button"
-import { SpotPrice } from "@/lib/types"
+import { Signal, SignalTradeResult, SpotPrice } from "@/lib/types"
 
 function Row({ label, children }: { label: string; children: React.ReactNode }) {
   return (
@@ -43,6 +43,86 @@ function SpotPriceRow({ tokenA, tokenB, price }: { tokenA: string; tokenB: strin
         <span><span className="text-muted-foreground">max </span>{price.max_price.toFixed(6)}</span>
       </div>
     </div>
+  )
+}
+
+const TRADE_TYPE_LABELS: Record<SignalTradeResult['trade_type'], string> = {
+  Successful: 'Successful',
+  FailedOnSlow: 'Failed on Slow',
+  FailedOnFast: 'Stuck on Fast',
+}
+
+const TRADE_TYPE_COLORS: Record<SignalTradeResult['trade_type'], string> = {
+  Successful: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+  FailedOnSlow: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
+  FailedOnFast: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
+}
+
+function TradeTypeBadge({ type }: { type: SignalTradeResult['trade_type'] }) {
+  return (
+    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${TRADE_TYPE_COLORS[type]}`}>
+      {TRADE_TYPE_LABELS[type]}
+    </span>
+  )
+}
+
+function TradeResultDetail({ trade, signal }: { trade: SignalTradeResult; signal: Signal }) {
+  const slowChain = signal.slow.chain
+  const fastChain = signal.fast.chain
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-3">
+        <TradeTypeBadge type={trade.trade_type} />
+        <span className="text-sm text-muted-foreground font-mono">#{trade.id}</span>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 pl-2">
+        <Row label="Slow Tx">
+          {trade.slow_tx_hash
+            ? <ExplorerLink chain={slowChain} type="tx" value={trade.slow_tx_hash} />
+            : <span className="text-muted-foreground">—</span>
+          }
+        </Row>
+        <Row label="Fast Tx">
+          {trade.trade_type === 'Successful'
+            ? <ExplorerLink chain={fastChain} type="tx" value={trade.fast_tx_hash} />
+            : trade.trade_type === 'FailedOnFast' && trade.fast_tx_hash
+              ? <ExplorerLink chain={fastChain} type="tx" value={trade.fast_tx_hash} />
+              : <span className="text-muted-foreground">—</span>
+          }
+        </Row>
+        {trade.trade_type === 'Successful' && (
+          <Row label="Realized Profit">
+            <TokenAmount amount={trade.realized_profit_str} symbol="USDC" />
+          </Row>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function TradeResultsCard({ signalId, signal }: { signalId: number; signal: Signal }) {
+  const { data: trades, isLoading } = useTradesBySignal(signalId, {
+    staleTime: 1000 * 60 * 5,
+  })
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle>Trade Result</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="text-sm text-muted-foreground py-4 text-center">Loading...</div>
+        ) : !trades || trades.length === 0 ? (
+          <div className="text-sm text-muted-foreground py-4 text-center">No trade recorded for this signal.</div>
+        ) : (
+          trades.map((trade) => (
+            <TradeResultDetail key={`${trade.trade_type}-${trade.id}`} trade={trade} signal={signal} />
+          ))
+        )}
+      </CardContent>
+    </Card>
   )
 }
 
@@ -238,6 +318,9 @@ export default function SignalPage({ params }: { params: Promise<{ id: string }>
           <SpotPriceRow tokenA="ETH" tokenB="USDC" price={signal.slow_prices_eth_usdc} />
         </CardContent>
       </Card>
+
+      {/* Trade Result */}
+      <TradeResultsCard signalId={signalId} signal={signal} />
     </main>
   )
 }

--- a/webapp/src/lib/api-client.tsx
+++ b/webapp/src/lib/api-client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { SpotPrice, Signal, SuccessfulTrade, FailedOnSlowTrade, FailedOnFastTrade, PaginatedResponse } from "@/lib/types";
+import { SpotPrice, Signal, SignalTradeResult, SuccessfulTrade, FailedOnSlowTrade, FailedOnFastTrade, PaginatedResponse } from "@/lib/types";
 import { QueryClient, useQuery, useQueryClient, UseQueryOptions, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { useStrategy } from "@/components/strategy-provider";
@@ -60,6 +60,10 @@ class ApiClient {
 
   async getSignal(id: number): Promise<Signal> {
     return this.requestSingle<Signal>(`/signals/${id}`);
+  }
+
+  async getTradesBySignal(signalId: number): Promise<SignalTradeResult[]> {
+    return this.requestSingle<SignalTradeResult[]>(`/trades/by-signal/${signalId}`);
   }
 
   async getSignals(pair: string, params: FetchParams): Promise<PaginatedResponse<Signal>> {
@@ -136,6 +140,14 @@ export function useSignal(id: number, options?: Partial<UseQueryOptions<Signal>>
     ...options,
     queryKey: ['signal', id],
     queryFn: () => apiClient.getSignal(id),
+  });
+}
+
+export function useTradesBySignal(signalId: number, options?: Partial<UseQueryOptions<SignalTradeResult[]>>) {
+  return useQuery<SignalTradeResult[]>({
+    ...options,
+    queryKey: ['signal_trades', signalId],
+    queryFn: () => apiClient.getTradesBySignal(signalId),
   });
 }
 

--- a/webapp/src/lib/types.ts
+++ b/webapp/src/lib/types.ts
@@ -88,6 +88,13 @@ export interface FailedOnFastTrade {
   fast_tx_hash: string | null;
 }
 
+// Matches SignalTradeResultResponse tagged enum — slim version without embedded signal,
+// used on the signal detail page where the signal is already loaded.
+export type SignalTradeResult =
+  | { trade_type: 'Successful'; id: number; slow_tx_hash: string; fast_tx_hash: string; realized_profit_str: string }
+  | { trade_type: 'FailedOnSlow'; id: number; slow_tx_hash: string | null }
+  | { trade_type: 'FailedOnFast'; id: number; slow_tx_hash: string; fast_tx_hash: string | null }
+
 export interface PaginationInfo {
   page: number;
   page_size: number;


### PR DESCRIPTION
## Summary

- Adds a **Trade Result** card to the signal detail page (`/signals/:id`) showing the outcome of trade execution for that signal
- New `GET /trades/by-signal/:signal_id` endpoint returns a slim response (no embedded signal) with `trade_type` tag + tx hashes + realized profit
- Three new DB queries (`get_{successful,failed_on_slow,failed_on_fast}_by_signal_id`) on `TradeRepository`
- Coloured badge per outcome: green Successful / red Failed on Slow / yellow Stuck on Fast
- ExplorerLinks for tx hashes; realized profit displayed via `TokenAmount` (USDC)

## Test plan

- [ ] Start backend + frontend locally
- [ ] Navigate to a signal that has a successful trade — confirm green badge, both tx links, and USDC profit amount appear
- [ ] Navigate to a signal with no trade — confirm "No trade recorded" placeholder
- [ ] Navigate to a failed-on-slow signal — confirm red badge, optional slow tx link, fast tx shows —
- [ ] Navigate to a failed-on-fast signal — confirm yellow badge, slow tx link, optional fast tx link

🤖 Generated with [Claude Code](https://claude.com/claude-code)